### PR TITLE
Fix area codes for French phone numbers

### DIFF
--- a/faker/providers/phone_number/fr_FR/__init__.py
+++ b/faker/providers/phone_number/fr_FR/__init__.py
@@ -202,7 +202,7 @@ class Provider(PhoneNumberProvider):
         "497",
         "498",
         "499",
-        "58 ",
+        "508",
         "516",
         "517",
         "518",


### PR DESCRIPTION
### What does this change

Fix a wrong area code for French phone numbers ("58 " instead of "508")

### What was wrong

French phone number generation could lead to invalid phone number like "058 XXXXXX"

